### PR TITLE
Move the context out of the business logic

### DIFF
--- a/cmd/permission/main.go
+++ b/cmd/permission/main.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/OpenSlides/openslides-permission-service/internal/definitions"
 	"github.com/OpenSlides/openslides-permission-service/pkg/permission"
 )
 
-type fakeDataProvider struct{}
+type fakeDataProvider struct {
+	ctx context.Context
+}
 
-func (dp fakeDataProvider) Get(ctx context.Context, fqfields ...definitions.Fqfield) ([]json.RawMessage, error) {
+func (dp fakeDataProvider) Get(fqfields ...definitions.Fqfield) ([]json.RawMessage, error) {
+	fmt.Printf("Access context: %p\n", &dp.ctx)
+	log.Println("TEST")
 	m := make([]json.RawMessage, len(fqfields))
 	for i := range fqfields {
 		m[i] = json.RawMessage(strconv.Itoa(i))
@@ -20,15 +25,34 @@ func (dp fakeDataProvider) Get(ctx context.Context, fqfields ...definitions.Fqfi
 	return m, nil
 }
 
+func (dp fakeDataProvider) setContext(ctx context.Context) {
+	dp.ctx = ctx
+}
+
 func main() {
 	myDataProvider := fakeDataProvider{}
 	ps := permission.New(myDataProvider)
+
+	myDataProvider.setContext(context.TODO())
 	result, addition, err := ps.IsAllowed("", 0, nil)
 	fmt.Println(result, addition, err)
+
+	myDataProvider.setContext(context.TODO())
 	result, addition, err = ps.IsAllowed("topic.create", 0, nil)
 	fmt.Println(result, addition, err)
+
+	myDataProvider.setContext(context.TODO())
+	data := definitions.FqfieldData{
+		"meeting_id": "1",
+	}
+	result, addition, err = ps.IsAllowed("topic.create", 0, data)
+	fmt.Println(result, addition, err)
+
+	myDataProvider.setContext(context.TODO())
 	result, addition, err = ps.IsAllowed("topic.update", 0, nil)
 	fmt.Println(result, addition, err)
+
+	myDataProvider.setContext(context.TODO())
 	result, addition, err = ps.IsAllowed("topic.delete", 0, nil)
 	fmt.Println(result, addition, err)
 }

--- a/internal/core/permission.go
+++ b/internal/core/permission.go
@@ -23,8 +23,8 @@ func NewPermissionService(externalDataprovider dataprovider.ExternalDataProvider
 // IsAllowed tells, if something is allowed.
 func (permissionService PermissionService) IsAllowed(name string, userID int, data definitions.FqfieldData) (bool, map[string]interface{}, error) {
 	if val, ok := Queries[name]; ok {
-		context := &allowed.IsAllowedParams{UserID: userID, Data: data, DataProvider: permissionService.dataprovider}
-		return val(context)
+		params := &allowed.IsAllowedParams{UserID: userID, Data: data, DataProvider: permissionService.dataprovider}
+		return val(params)
 	}
 
 	return false, nil, fmt.Errorf("no such query: \"%s\"", name)

--- a/internal/dataprovider/dataprovider.go
+++ b/internal/dataprovider/dataprovider.go
@@ -1,7 +1,6 @@
 package dataprovider
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -13,7 +12,7 @@ import (
 // required by the permission service.
 type ExternalDataProvider interface {
 	// If a field does not exist, it is not returned.
-	Get(ctx context.Context, keys ...string) ([]json.RawMessage, error)
+	Get(keys ...string) ([]json.RawMessage, error)
 }
 
 // DataProvider is a wrapper around permission.ExternalDataProvider that
@@ -29,7 +28,7 @@ func NewDataProvider(externalDataprovider ExternalDataProvider) DataProvider {
 
 // GetString returns the value of a string field.
 func (dp DataProvider) GetString(fqfield definitions.Fqfield) (string, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +45,7 @@ func (dp DataProvider) GetString(fqfield definitions.Fqfield) (string, error) {
 //
 // If an error happens, an empty string is returned.
 func (dp DataProvider) GetStringWithDefault(fqfield definitions.Fqfield, defaultValue string) string {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return ""
 	}
@@ -59,7 +58,7 @@ func (dp DataProvider) GetStringWithDefault(fqfield definitions.Fqfield, default
 
 // GetStringArrayWithDefault returns a value, that conatins a list of strings.
 func (dp DataProvider) GetStringArrayWithDefault(fqfield definitions.Fqfield, defaultValue []string) ([]string, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +77,7 @@ func (dp DataProvider) GetStringArrayWithDefault(fqfield definitions.Fqfield, de
 
 // GetMany returns a list of values.
 func (dp DataProvider) GetMany(fqfields []definitions.Fqfield) map[definitions.Fqfield]definitions.Value {
-	result, err := dp.externalDataprovider.Get(context.TODO(), fqfields...)
+	result, err := dp.externalDataprovider.Get(fqfields...)
 	if err != nil {
 		panic("TODO: Please fix me:" + err.Error())
 	}
@@ -94,7 +93,7 @@ func (dp DataProvider) GetMany(fqfields []definitions.Fqfield) map[definitions.F
 //
 // If an error happens, it returns false.
 func (dp DataProvider) Exists(fqfield definitions.Fqfield) bool {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return false
 	}
@@ -104,7 +103,7 @@ func (dp DataProvider) Exists(fqfield definitions.Fqfield) bool {
 
 // GetInt returns an int value.
 func (dp DataProvider) GetInt(fqfield definitions.Fqfield) (int, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return 0, err
 	}
@@ -123,7 +122,7 @@ func (dp DataProvider) GetInt(fqfield definitions.Fqfield) (int, error) {
 
 // GetIntWithDefault returns a int value or the default value.
 func (dp DataProvider) GetIntWithDefault(fqfield definitions.Fqfield, defaultValue int) (int, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return 0, err
 	}
@@ -142,7 +141,7 @@ func (dp DataProvider) GetIntWithDefault(fqfield definitions.Fqfield, defaultVal
 
 // GetIntArray returns an array of ints.
 func (dp DataProvider) GetIntArray(fqfield definitions.Fqfield) ([]int, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +159,7 @@ func (dp DataProvider) GetIntArray(fqfield definitions.Fqfield) ([]int, error) {
 
 // GetIntArrayWithDefault returns an int array or the default value.
 func (dp DataProvider) GetIntArrayWithDefault(fqfield definitions.Fqfield, defaultValue []int) ([]int, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +177,7 @@ func (dp DataProvider) GetIntArrayWithDefault(fqfield definitions.Fqfield, defau
 
 // GetBoolWithDefault returns a bool value or the defaultValue.
 func (dp DataProvider) GetBoolWithDefault(fqfield definitions.Fqfield, defaultValue bool) (bool, error) {
-	fields, err := dp.externalDataprovider.Get(context.TODO(), fqfield)
+	fields, err := dp.externalDataprovider.Get(fqfield)
 	if err != nil {
 		return false, err
 	}

--- a/internal/tests/shared.go
+++ b/internal/tests/shared.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"strconv"
 
@@ -166,7 +165,7 @@ func (t *TestDataProvider) Set(fqfield definitions.Fqfield, value definitions.Va
 }
 
 // Get does ...
-func (t TestDataProvider) Get(ctx context.Context, fqfields ...definitions.Fqfield) ([]json.RawMessage, error) {
+func (t TestDataProvider) Get(fqfields ...definitions.Fqfield) ([]json.RawMessage, error) {
 	data := make([]json.RawMessage, len(fqfields))
 	for i, field := range fqfields {
 		value, ok := t.Data[field]

--- a/pkg/permission/permission.go
+++ b/pkg/permission/permission.go
@@ -1,7 +1,6 @@
 package permission
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/OpenSlides/openslides-permission-service/internal/core"
@@ -16,7 +15,7 @@ func New(dataprovider ExternalDataProvider) Permission {
 // required by the permission service.
 type ExternalDataProvider interface {
 	// If a field does not exist, it is not returned.
-	Get(ctx context.Context, keys ...string) ([]json.RawMessage, error)
+	Get(keys ...string) ([]json.RawMessage, error)
 }
 
 // Permission can tell, if a user has the permission for some data.


### PR DESCRIPTION
@ostcar You do not need to have the context everywhere - this keeps the business logic clean.

You have to write a wrapper, but this should not be complicated at all. See the main.go; it is easy