### PR TITLE
mediafile.can_see

### DIFF
--- a/internal/collection/mediafile.go
+++ b/internal/collection/mediafile.go
@@ -78,7 +78,7 @@ func (m *mediafile) canSeeAction(ctx context.Context, userID int, payload map[st
 		return false, nil
 	}
 
-	if perms.IsAdmin() {
+	if perms.Has("mediafile.can_manage") {
 		return true, nil
 	}
 

--- a/tests/mediafile/can_see_mediafile.yml
+++ b/tests/mediafile/can_see_mediafile.yml
@@ -19,6 +19,10 @@ cases:
 
   is_allowed: true
 
+- name: meeting manager
+  permission: mediafile.can_manage
+  is_allowed: true
+
 - name: user not in meeting
   meeting_id: 2
 


### PR DESCRIPTION
managers can see all mediafiles

Fixes #125

This will close the mediafile.can_see action. Is it ok to merge it?