### PR TITLE
setting_manager can see all meeting-fields

### DIFF
--- a/internal/collection/meeting.go
+++ b/internal/collection/meeting.go
@@ -56,6 +56,11 @@ func (m *meeting) read(ctx context.Context, userID int, fqfields []perm.FQField,
 				return fmt.Errorf("getting perms: %w", err)
 			}
 		}
+
+		if perms.Has("meeting.can_manage_settings") {
+			result[fqfield.String()] = true
+		}
+
 		switch fqfield.Field {
 		case "enable_anonymous", "id":
 		case "welcome_title", "welcome_text":

--- a/internal/collection/meeting.go
+++ b/internal/collection/meeting.go
@@ -57,21 +57,17 @@ func (m *meeting) read(ctx context.Context, userID int, fqfields []perm.FQField,
 			}
 		}
 
-		if perms.Has("meeting.can_manage_settings") {
-			result[fqfield.String()] = true
-		}
-
 		switch fqfield.Field {
 		case "enable_anonymous", "id":
 		case "welcome_title", "welcome_text":
-			if !perms.Has(perm.MeetingCanSeeFrontpage) {
+			if !perms.Has(perm.MeetingCanSeeFrontpage) && !perms.Has("meeting.can_manage_settings") {
 				continue
 			}
 		case "conference_stream_url", "conference_stream_poster_url":
-			if !perms.Has(perm.MeetingCanSeeLivestream) {
+			if !perms.Has(perm.MeetingCanSeeLivestream) && !perms.Has("meeting.can_manage_settings") {
 				continue
 			}
-		case "present_user_ids":
+		case "present_user_ids", "temporary_user_ids", "guest_ids", "user_ids":
 			if !perms.Has(perm.UserCanSee) {
 				continue
 			}

--- a/internal/tests/case.go
+++ b/internal/tests/case.go
@@ -260,10 +260,8 @@ func (c *Case) initSub() {
 		}
 		s.DB = db
 
-		if s.FQFields == nil {
+		if s.FQFields == nil && s.FQIDs == nil {
 			s.FQFields = c.FQFields
-		}
-		if s.FQIDs == nil {
 			s.FQIDs = c.FQIDs
 		}
 

--- a/tests/meeting/read.yml
+++ b/tests/meeting/read.yml
@@ -53,3 +53,8 @@ cases:
   - meeting/1/welcome_text
   - meeting/1/conference_stream_url
   - meeting/1/conference_stream_poster_url
+
+- name: can manage config
+  permission: meeting.can_manage_settings
+  can_see:
+  - meeting/1

--- a/tests/meeting/read.yml
+++ b/tests/meeting/read.yml
@@ -22,6 +22,9 @@ cases:
   - meeting/1/conference_stream_url
   - meeting/1/conference_stream_poster_url
   - meeting/1/present_user_ids
+  - meeting/1/temporary_user_ids
+  - meeting/1/guest_ids
+  - meeting/1/user_ids
 
 - name: member
   can_not_see:
@@ -30,31 +33,46 @@ cases:
   - meeting/1/conference_stream_url
   - meeting/1/conference_stream_poster_url
   - meeting/1/present_user_ids
+  - meeting/1/temporary_user_ids
+  - meeting/1/guest_ids
+  - meeting/1/user_ids
 
 
 - name: can_see_frontpage
   permission: meeting.can_see_frontpage
-  can_not_see:
-  - meeting/1/conference_stream_url
-  - meeting/1/conference_stream_poster_url
-  - meeting/1/present_user_ids
+  fqfields:
+  - meeting/1/welcome_title
+  - meeting/1/welcome_text
+  can_see:
+  - meeting/1/welcome_title
+  - meeting/1/welcome_text
 
 - name: can_see_livestream
   permission: meeting.can_see_livestream
-  can_not_see:
-  - meeting/1/welcome_title
-  - meeting/1/welcome_text
-  - meeting/1/present_user_ids
-
-- name: can see user list
-  permission: user.can_see
-  can_not_see:
-  - meeting/1/welcome_title
-  - meeting/1/welcome_text
+  fqfields:
+  - meeting/1/conference_stream_url
+  - meeting/1/conference_stream_poster_url
+  can_see:
   - meeting/1/conference_stream_url
   - meeting/1/conference_stream_poster_url
 
+- name: can see user list
+  permission: user.can_see
+  fqfields:
+  - meeting/1/present_user_ids
+  - meeting/1/temporary_user_ids
+  - meeting/1/guest_ids
+  - meeting/1/user_ids
+  can_see:
+  - meeting/1/present_user_ids
+  - meeting/1/temporary_user_ids
+  - meeting/1/guest_ids
+  - meeting/1/user_ids
+
 - name: can manage config
   permission: meeting.can_manage_settings
-  can_see:
-  - meeting/1
+  can_not_see:
+  - meeting/1/present_user_ids
+  - meeting/1/temporary_user_ids
+  - meeting/1/guest_ids
+  - meeting/1/user_ids


### PR DESCRIPTION
@emanuelschuetze Please review the test

Should someone with perm meeting.can_manage_settings see the following fields?

- [x] welcome_title
- [x] welcome_text
- [x] conference_stream_url
- [x] conference_stream_poster_url
- [ ] present_user_ids