### PR TITLE
Service should listen on all addresses

### DIFF
--- a/cmd/permission/main.go
+++ b/cmd/permission/main.go
@@ -67,7 +67,7 @@ func run() error {
 	permHTTP.IsAllowed(mux, ps)
 
 	// Create http server.
-	listenAddr := env["PERMISSION_HOST"] + ":" + env["PERMISSION_PORT"]
+	listenAddr := ":" + env["PERMISSION_PORT"]
 	fmt.Printf("Listen on: %s\n", listenAddr)
 	srv := &http.Server{
 		Addr:    listenAddr,


### PR DESCRIPTION
In docker, you cannot bind yourself to your hostname. This is the
result:
```
Apr  1 10:27:07 docker-dev1 docker/os4_permission.1.t7id1u9xmq9src7rdjuehwd8o/b09cb7667dd0[10357]: Use datastore reader on http://datastore-reader:9010
Apr  1 10:27:07 docker-dev1 docker/os4_permission.1.t7id1u9xmq9src7rdjuehwd8o/b09cb7667dd0[10357]: Listen on: permission:9005
Apr  1 10:27:17 docker-dev1 docker/os4_permission.1.t7id1u9xmq9src7rdjuehwd8o/b09cb7667dd0[10357]: 2021/04/01 08:27:17 Fatal error: http server: listen tcp: lookup permission on 127.0.0.11:53: no such host
```

I quickly removed it, so the deployment works. It may be refactored
later.